### PR TITLE
Make the repository a Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sgreben/http-file-server
+
+go 1.16


### PR DESCRIPTION
Once this repository is a Go module, http-file-server can be installed using `go install`. I find this to be the easiest way of installation.